### PR TITLE
feat: Add scheduled workflow for daily deployment to GitHub Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - source
   workflow_dispatch:
+  schedule:
+    # Run daily at 1 AM PST (9 AM UTC)
+    - cron: '0 9 * * *'
 
 permissions:
   contents: write
@@ -50,14 +53,14 @@ jobs:
             "
 
       - name: Upload build artifacts (for deployment)
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'schedule'
         uses: actions/upload-artifact@v4
         with:
           name: dist
           path: './dist'
 
   deploy:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'schedule'
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying the site to ensure it runs automatically on a daily schedule in addition to manual and push-based triggers. The changes primarily focus on enhancing automation and deployment reliability.

**Workflow automation improvements:**

* Added a scheduled trigger to `.github/workflows/gh-pages.yml` so the workflow runs daily at 1 AM PST (9 AM UTC).

**Deployment logic updates:**

* Updated the build artifact upload and deployment steps to run not only on `push` events but also on scheduled runs, ensuring daily deployments.